### PR TITLE
Eye rigger

### DIFF
--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -817,38 +817,34 @@ def eyeRig(eyeMesh=None,
                                          n='skinClsEye')
 
 
-class widget_get_set(object):
+def widget_get(widget):
+    if isinstance(widget, QtWidgets.QDoubleSpinBox):
+        return widget.value()
+    if isinstance(widget, QtWidgets.QSpinBox):
+        return widget.value()
+    if isinstance(widget, QtWidgets.QLineEdit):
+        return widget.text()
+    if isinstance(widget, QtWidgets.QCheckBox):
+        return widget.isChecked()
 
-    def __init__(self, widget):
-        self.widget = widget
+    return None
 
-    def get(self):
-        if isinstance(self.widget, QtWidgets.QDoubleSpinBox):
-            return self.widget.value()
-        if isinstance(self.widget, QtWidgets.QSpinBox):
-            return self.widget.value()
-        if isinstance(self.widget, QtWidgets.QLineEdit):
-            return self.widget.text()
-        if isinstance(self.widget, QtWidgets.QCheckBox):
-            return self.widget.isChecked()
 
-        return None
+def widget_set(widget, value):
+    if isinstance(widget, QtWidgets.QDoubleSpinBox):
+        widget.setValue(value)
+        return
+    if isinstance(widget, QtWidgets.QSpinBox):
+        widget.setValue(value)
+        return
+    if isinstance(widget, QtWidgets.QLineEdit):
+        widget.setText(value)
+        return
+    if isinstance(widget, QtWidgets.QCheckBox):
+        widget.setChecked(value)
+        return
 
-    def set(self, value):
-        if isinstance(self.widget, QtWidgets.QDoubleSpinBox):
-            self.widget.setValue(value)
-            return
-        if isinstance(self.widget, QtWidgets.QSpinBox):
-            self.widget.setValue(value)
-            return
-        if isinstance(self.widget, QtWidgets.QLineEdit):
-            self.widget.setText(value)
-            return
-        if isinstance(self.widget, QtWidgets.QCheckBox):
-            self.widget.setChecked(value)
-            return
-
-        raise ValueError("Widget {0} was not recognized.".format(self.widget))
+    raise ValueError("Widget {0} was not recognized.".format(widget))
 
 ##########################################################
 # Eye Rig UI
@@ -1213,7 +1209,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
     def populateDict(self):
         settings = {}
         for attr, widget in self.__dict__.iteritems():
-            value = widget_get_set(widget).get()
+            value = widget_get(widget)
             if value is not None:
                 settings[attr] = value
 
@@ -1257,7 +1253,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             if attr not in settings.keys():
                 continue
 
-            widget_get_set(widget).set(settings[attr])
+            widget_set(widget, settings[attr])
 
 
 # build lips from json file:

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -856,7 +856,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.extCorner_button = QtWidgets.QPushButton("<<")
 
         # Blink heigh slider
-        self.blinkHeigh_group = QtWidgets.QGroupBox("Blink High")
+        self.blinkHeigh_group = QtWidgets.QGroupBox("Blink Height")
         self.blinkHeight_value = QtWidgets.QSpinBox()
         self.blinkHeight_value.setRange(0, 100)
         self.blinkHeight_value.setSingleStep(10)

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -40,7 +40,8 @@ def eyeRig(eyeMesh=None,
            upperVTrack=1,
            upperHTrack=0.5,
            lowerVTrack=1,
-           lowerHTrack=0.5):
+           lowerHTrack=0.5,
+           aim_controller=""):
 
     """Create eyelid and eye rig
 
@@ -312,14 +313,24 @@ def eyeRig(eyeMesh=None,
                                               axis="zy", negate=False)
 
     radius = abs((localBBox[0][0] - localBBox[1][0]) / 1.7)
-    arrow_npo = primitive.addTransform(eye_root, setName("aim_npo"), t_arrow)
-    arrow_ctl = icon.create(arrow_npo,
-                            setName("aim_%s" % ctlName),
-                            t_arrow,
-                            icon="arrow",
-                            w=1,
-                            po=datatypes.Vector(0, 0, radius),
-                            color=4)
+
+    arrow_ctl = None
+    arrow_npo = None
+    if aim_controller:
+        arrow_ctl = pm.PyNode(aim_controller)
+    else:
+        arrow_npo = primitive.addTransform(
+            eye_root, setName("aim_npo"), t_arrow
+        )
+        arrow_ctl = icon.create(
+            arrow_npo,
+            setName("aim_%s" % ctlName),
+            t_arrow,
+            icon="arrow",
+            w=1,
+            po=datatypes.Vector(0, 0, radius),
+            color=4
+        )
     if len(ctlName.split("_")) == 2 and ctlName.split("_")[-1] == "ghost":
         pass
     else:
@@ -951,6 +962,9 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.parent_label = QtWidgets.QLabel("Rig Parent:")
         self.parent_node = QtWidgets.QLineEdit()
         self.parent_button = QtWidgets.QPushButton("<<")
+        self.aim_controller_label = QtWidgets.QLabel("Aim Controller:")
+        self.aim_controller = QtWidgets.QLineEdit()
+        self.aim_controller_button = QtWidgets.QPushButton("<<")
         self.ctlShapeOffset_label = QtWidgets.QLabel("Controls Offset:")
         self.offset = QtWidgets.QDoubleSpinBox()
         self.offset.setRange(0, 10)
@@ -1066,6 +1080,9 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         parent_layout.addWidget(self.parent_label)
         parent_layout.addWidget(self.parent_node)
         parent_layout.addWidget(self.parent_button)
+        parent_layout.addWidget(self.aim_controller_label)
+        parent_layout.addWidget(self.aim_controller)
+        parent_layout.addWidget(self.aim_controller_button)
         offset_layout = QtWidgets.QHBoxLayout()
         offset_layout.addWidget(self.ctlShapeOffset_label)
         offset_layout.addWidget(self.offset)
@@ -1127,6 +1144,9 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
                                                     self.eyeMesh))
         self.parent_button.clicked.connect(partial(self.populate_object,
                                                    self.parent_node))
+        self.aim_controller_button.clicked.connect(
+            partial(self.populate_object, self.aim_controller)
+        )
         self.headJnt_button.clicked.connect(partial(self.populate_object,
                                                     self.headJnt,
                                                     1))

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -559,13 +559,13 @@ def eyeRig(eyeMesh=None,
     bs_mid[0].attr(upTarget.name()).set(blinkH)
 
     # joints root
-    jnt_root = None
+    jnt_root = primitive.addTransformFromPos(
+        eye_root, setName("joints"), pos=bboxCenter
+    )
     if deformers_group:
-        jnt_root = pm.PyNode(deformers_group)
-    else:
-        jnt_root = primitive.addTransformFromPos(
-            eye_root, setName("joints"), pos=bboxCenter
-        )
+        deformers_group = pm.PyNode(deformers_group)
+        pm.parentConstraint(eye_root, jnt_root, mo=True)
+        deformers_group.addChild(jnt_root)
 
     # head joint
     if headJnt:

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -36,7 +36,11 @@ def eyeRig(eyeMesh,
            intCorner=None,
            extCorner=None,
            ctlGrp=None,
-           defGrp=None):
+           defGrp=None,
+           upperVTrack=1,
+           upperHTrack=0.5,
+           lowerVTrack=1,
+           lowerHTrack=0.5):
 
     """Create eyelid and eye rig
 
@@ -659,14 +663,14 @@ def eyeRig(eyeMesh,
     upVTracking_att = attribute.addAttribute(up_ctl,
                                              "vTracking",
                                              "float",
-                                             .02,
+                                             upperVTrack,
                                              minValue=0,
                                              keyable=False,
                                              channelBox=True)
     upHTracking_att = attribute.addAttribute(up_ctl,
                                              "hTracking",
                                              "float",
-                                             .01,
+                                             upperHTrack,
                                              minValue=0,
                                              keyable=False,
                                              channelBox=True)
@@ -674,14 +678,14 @@ def eyeRig(eyeMesh,
     lowVTracking_att = attribute.addAttribute(low_ctl,
                                               "vTracking",
                                               "float",
-                                              .01,
+                                              lowerVTrack,
                                               minValue=0,
                                               keyable=False,
                                               channelBox=True)
     lowHTracking_att = attribute.addAttribute(low_ctl,
                                               "hTracking",
                                               "float",
-                                              .01,
+                                              lowerHTrack,
                                               minValue=0,
                                               keyable=False,
                                               channelBox=True)
@@ -867,6 +871,17 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             self.blinkHeight_slider.maximum() / 10.0)
         self.blinkHeight_slider.setValue(20)
 
+        # vTrack and hTrack
+        self.tracking_group = QtWidgets.QGroupBox("Tracking")
+        self.upperVTrack_spinbox = QtWidgets.QDoubleSpinBox()
+        self.upperVTrack_spinbox.setValue(1)
+        self.upperHTrack_spinbox = QtWidgets.QDoubleSpinBox()
+        self.upperHTrack_spinbox.setValue(0.5)
+        self.lowerVTrack_spinbox = QtWidgets.QDoubleSpinBox()
+        self.lowerVTrack_spinbox.setValue(1)
+        self.lowerHTrack_spinbox = QtWidgets.QDoubleSpinBox()
+        self.lowerHTrack_spinbox.setValue(0.5)
+
         # Name prefix
         self.prefix_group = QtWidgets.QGroupBox("Name Prefix")
         self.prefix_lineEdit = QtWidgets.QLineEdit()
@@ -953,6 +968,21 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         blinkHeight_layout.addWidget(self.blinkHeight_value)
         blinkHeight_layout.addWidget(self.blinkHeight_slider)
         self.blinkHeigh_group.setLayout(blinkHeight_layout)
+        # Tracking Layout
+        tracking_layout = QtWidgets.QVBoxLayout()
+        layout = QtWidgets.QHBoxLayout()
+        layout.addWidget(QtWidgets.QLabel("Upper Vertical"))
+        layout.addWidget(self.upperVTrack_spinbox)
+        layout.addWidget(QtWidgets.QLabel("Upper Horizontal"))
+        layout.addWidget(self.upperHTrack_spinbox)
+        tracking_layout.addLayout(layout)
+        layout = QtWidgets.QHBoxLayout()
+        layout.addWidget(QtWidgets.QLabel("Lower Vertical"))
+        layout.addWidget(self.lowerVTrack_spinbox)
+        layout.addWidget(QtWidgets.QLabel("Lower Horizontal"))
+        layout.addWidget(self.lowerHTrack_spinbox)
+        tracking_layout.addLayout(layout)
+        self.tracking_group.setLayout(tracking_layout)
 
         # joints Layout
         headJnt_layout = QtWidgets.QHBoxLayout()
@@ -1018,6 +1048,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         options_layout.addLayout(parent_layout)
         options_layout.addLayout(offset_layout)
         options_layout.addWidget(self.blinkHeigh_group)
+        options_layout.addWidget(self.tracking_group)
         options_layout.addWidget(self.sideRange_check)
         options_layout.addLayout(ctlGrp_layout)
         options_layout.addLayout(deformersGrp_layout)

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -860,7 +860,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.extCorner_button = QtWidgets.QPushButton("<<")
 
         # Blink heigh slider
-        self.blinkHeigh_group = QtWidgets.QGroupBox("Blink Height")
+        self.blinkHeight_group = QtWidgets.QGroupBox("Blink Height")
         self.blinkHeight_value = QtWidgets.QSpinBox()
         self.blinkHeight_value.setRange(0, 100)
         self.blinkHeight_value.setSingleStep(10)
@@ -962,12 +962,13 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         geometryInput_layout.addLayout(edgeloop_layout)
         self.geometryInput_group.setLayout(geometryInput_layout)
 
-        # Blink High Layout
+        # Blink Height Layout
         blinkHeight_layout = QtWidgets.QHBoxLayout()
         blinkHeight_layout.setContentsMargins(1, 1, 1, 1)
         blinkHeight_layout.addWidget(self.blinkHeight_value)
         blinkHeight_layout.addWidget(self.blinkHeight_slider)
-        self.blinkHeigh_group.setLayout(blinkHeight_layout)
+        self.blinkHeight_group.setLayout(blinkHeight_layout)
+
         # Tracking Layout
         tracking_layout = QtWidgets.QVBoxLayout()
         layout = QtWidgets.QHBoxLayout()
@@ -1047,7 +1048,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         options_layout.setContentsMargins(6, 1, 6, 2)
         options_layout.addLayout(parent_layout)
         options_layout.addLayout(offset_layout)
-        options_layout.addWidget(self.blinkHeigh_group)
+        options_layout.addWidget(self.blinkHeight_group)
         options_layout.addWidget(self.tracking_group)
         options_layout.addWidget(self.sideRange_check)
         options_layout.addLayout(ctlGrp_layout)

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -1271,10 +1271,10 @@ def showEyeRigUI(*args):
 
 
 if __name__ == "__main__":
-    #showEyeRigUI()
+    showEyeRigUI()
 
-    path = r"C:\Users\admin\Desktop\temp.eyes"
-    eyesFromfile(path)
+    # path = r"C:\Users\admin\Desktop\temp.eyes"
+    # eyesFromfile(path)
 
     # path = "C:\\Users\\miquel\\Desktop\\eye_R.eyes"
     # eyesFromfile(path)

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -61,8 +61,14 @@ def eyeRig(eyeMesh=None,
         customCorner (bool, optional): Description
         intCorner (None, optional): Description
         extCorner (None, optional): Description
-        ctlGrp (None, optional): Description
-        defGrp (None, optional): Description
+        ctlSet (None, optional): Description
+        defSet (None, optional): Description
+        upperVTrack (None, optional): Description
+        upperHTrack (None, optional): Description
+        lowerVTrack (None, optional): Description
+        lowerHTrack (None, optional): Description
+        aim_controller (None, optional): Description
+        deformers_group (None, optional): Description
 
     Returns:
         TYPE: Description

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -719,11 +719,21 @@ def eyeRig(eyeMesh=None,
     mult_node = node.createMulNode(upVTracking_att, aimTrigger_ref.attr("ty"))
     pm.connectAttr(mult_node + ".outputX", trackLvl[0].attr("ty"))
     mult_node = node.createMulNode(upHTracking_att, aimTrigger_ref.attr("tx"))
+    # Correct right side horizontal tracking
+    if side == "R":
+        mult_node = node.createMulNode(
+            mult_node.attr("outputX"), -1
+        )
     pm.connectAttr(mult_node + ".outputX", trackLvl[0].attr("tx"))
 
     mult_node = node.createMulNode(lowVTracking_att, aimTrigger_ref.attr("ty"))
     pm.connectAttr(mult_node + ".outputX", trackLvl[1].attr("ty"))
     mult_node = node.createMulNode(lowHTracking_att, aimTrigger_ref.attr("tx"))
+    # Correct right side horizontal tracking
+    if side == "R":
+        mult_node = node.createMulNode(
+            mult_node.attr("outputX"), -1
+        )
     pm.connectAttr(mult_node + ".outputX", trackLvl[1].attr("tx"))
 
     # Tension on blink

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -20,16 +20,16 @@ from mgear import rigbits
 ##########################################################
 
 
-def eyeRig(eyeMesh,
-           edgeLoop,
-           blinkH,
-           namePrefix,
-           offset,
-           rigidLoops,
-           falloffLoops,
-           headJnt,
-           doSkin,
-           parent=None,
+def eyeRig(eyeMesh=None,
+           edgeLoop="",
+           blinkH=20,
+           namePrefix="eye",
+           offset=0.05,
+           rigidLoops=2,
+           falloffLoops=4,
+           headJnt=None,
+           doSkin=True,
+           parent_node=None,
            ctlName="ctl",
            sideRange=False,
            customCorner=False,
@@ -54,7 +54,7 @@ def eyeRig(eyeMesh,
         falloffLoops (TYPE): Description
         headJnt (TYPE): Description
         doSkin (TYPE): Description
-        parent (None, optional): Description
+        parent_node (None, optional): Description
         ctlName (str, optional): Description
         sideRange (bool, optional): Description
         customCorner (bool, optional): Description
@@ -88,6 +88,9 @@ def eyeRig(eyeMesh,
             pm.displayWarning("Please set the Head Jnt or unCheck "
                               "Compute Topological Autoskin")
             return
+
+    # Convert data
+    blinkH = blinkH / 100.0
 
     # Initial Data
     bboxCenter = meshNavigation.bboxCenter(eyeMesh)
@@ -709,14 +712,14 @@ def eyeRig(eyeMesh,
     ###########################################
     # Reparenting
     ###########################################
-    if parent:
+    if parent_node:
         try:
-            if isinstance(parent, basestring):
-                parent = pm.PyNode(parent)
-            parent.addChild(eye_root)
+            if isinstance(parent_node, basestring):
+                parent_node = pm.PyNode(parent_node)
+            parent_node.addChild(eye_root)
         except pm.MayaNodeError:
             pm.displayWarning("The eye rig can not be parent to: %s. Maybe "
-                              "this object doesn't exist." % parent)
+                              "this object doesn't exist." % parent_node)
 
     ###########################################
     # Auto Skinning
@@ -875,30 +878,30 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         # Geometry input controls
         self.geometryInput_group = QtWidgets.QGroupBox("Geometry Input")
         self.eyeball_label = QtWidgets.QLabel("Eyeball:")
-        self.eyeball_lineEdit = QtWidgets.QLineEdit()
+        self.eyeMesh = QtWidgets.QLineEdit()
         self.eyeball_button = QtWidgets.QPushButton("<<")
         self.edgeloop_label = QtWidgets.QLabel("Edge Loop:")
-        self.edgeloop_lineEdit = QtWidgets.QLineEdit()
+        self.edgeLoop = QtWidgets.QLineEdit()
         self.edgeloop_button = QtWidgets.QPushButton("<<")
 
         # Manual corners
         self.manualCorners_group = QtWidgets.QGroupBox("Custom Eye Corners")
-        self.manualCorners_check = QtWidgets.QCheckBox(
+        self.customCorner = QtWidgets.QCheckBox(
             "Set Manual Vertex Corners")
-        self.manualCorners_check.setChecked(False)
+        self.customCorner.setChecked(False)
         self.intCorner_label = QtWidgets.QLabel("Internal Corner")
-        self.intCorner_lineEdit = QtWidgets.QLineEdit()
+        self.intCorner = QtWidgets.QLineEdit()
         self.intCorner_button = QtWidgets.QPushButton("<<")
         self.extCorner_label = QtWidgets.QLabel("External Corner")
-        self.extCorner_lineEdit = QtWidgets.QLineEdit()
+        self.extCorner = QtWidgets.QLineEdit()
         self.extCorner_button = QtWidgets.QPushButton("<<")
 
         # Blink heigh slider
         self.blinkHeight_group = QtWidgets.QGroupBox("Blink Height")
-        self.blinkHeight_value = QtWidgets.QSpinBox()
-        self.blinkHeight_value.setRange(0, 100)
-        self.blinkHeight_value.setSingleStep(10)
-        self.blinkHeight_value.setValue(20)
+        self.blinkH = QtWidgets.QSpinBox()
+        self.blinkH.setRange(0, 100)
+        self.blinkH.setSingleStep(10)
+        self.blinkH.setValue(20)
         self.blinkHeight_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.blinkHeight_slider.setRange(0, 100)
         self.blinkHeight_slider.setSingleStep(
@@ -907,66 +910,66 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
         # vTrack and hTrack
         self.tracking_group = QtWidgets.QGroupBox("Tracking")
-        self.upperVTrack_spinbox = QtWidgets.QDoubleSpinBox()
-        self.upperVTrack_spinbox.setValue(1)
-        self.upperHTrack_spinbox = QtWidgets.QDoubleSpinBox()
-        self.upperHTrack_spinbox.setValue(0.5)
-        self.lowerVTrack_spinbox = QtWidgets.QDoubleSpinBox()
-        self.lowerVTrack_spinbox.setValue(1)
-        self.lowerHTrack_spinbox = QtWidgets.QDoubleSpinBox()
-        self.lowerHTrack_spinbox.setValue(0.5)
+        self.upperVTrack = QtWidgets.QDoubleSpinBox()
+        self.upperVTrack.setValue(1)
+        self.upperHTrack = QtWidgets.QDoubleSpinBox()
+        self.upperHTrack.setValue(0.5)
+        self.lowerVTrack = QtWidgets.QDoubleSpinBox()
+        self.lowerVTrack.setValue(1)
+        self.lowerHTrack = QtWidgets.QDoubleSpinBox()
+        self.lowerHTrack.setValue(0.5)
 
         # Name prefix
         self.prefix_group = QtWidgets.QGroupBox("Name Prefix")
-        self.prefix_lineEdit = QtWidgets.QLineEdit()
-        self.prefix_lineEdit.setText("eye")
+        self.namePrefix = QtWidgets.QLineEdit()
+        self.namePrefix.setText("eye")
         self.control_group = QtWidgets.QGroupBox("Control Name Extension")
-        self.control_lineEdit = QtWidgets.QLineEdit()
-        self.control_lineEdit.setText("ctl")
+        self.ctlName = QtWidgets.QLineEdit()
+        self.ctlName.setText("ctl")
 
         # joints
         self.joints_group = QtWidgets.QGroupBox("Joints")
         self.headJnt_label = QtWidgets.QLabel("Head or Eye area Joint:")
-        self.headJnt_lineEdit = QtWidgets.QLineEdit()
+        self.headJnt = QtWidgets.QLineEdit()
         self.headJnt_button = QtWidgets.QPushButton("<<")
 
         # Topological Autoskin
         self.topoSkin_group = QtWidgets.QGroupBox("Skin")
         self.rigidLoops_label = QtWidgets.QLabel("Rigid Loops:")
-        self.rigidLoops_value = QtWidgets.QSpinBox()
-        self.rigidLoops_value.setRange(0, 30)
-        self.rigidLoops_value.setSingleStep(1)
-        self.rigidLoops_value.setValue(2)
+        self.rigidLoops = QtWidgets.QSpinBox()
+        self.rigidLoops.setRange(0, 30)
+        self.rigidLoops.setSingleStep(1)
+        self.rigidLoops.setValue(2)
         self.falloffLoops_label = QtWidgets.QLabel("Falloff Loops:")
-        self.falloffLoops_value = QtWidgets.QSpinBox()
-        self.falloffLoops_value.setRange(0, 30)
-        self.falloffLoops_value.setSingleStep(1)
-        self.falloffLoops_value.setValue(4)
+        self.falloffLoops = QtWidgets.QSpinBox()
+        self.falloffLoops.setRange(0, 30)
+        self.falloffLoops.setSingleStep(1)
+        self.falloffLoops.setValue(4)
 
-        self.topSkin_check = QtWidgets.QCheckBox(
+        self.doSkin = QtWidgets.QCheckBox(
             'Compute Topological Autoskin')
-        self.topSkin_check.setChecked(True)
+        self.doSkin.setChecked(True)
 
         # Options
         self.options_group = QtWidgets.QGroupBox("Options")
         self.parent_label = QtWidgets.QLabel("Rig Parent:")
-        self.parent_lineEdit = QtWidgets.QLineEdit()
+        self.parent_node = QtWidgets.QLineEdit()
         self.parent_button = QtWidgets.QPushButton("<<")
         self.ctlShapeOffset_label = QtWidgets.QLabel("Controls Offset:")
-        self.ctlShapeOffset_value = QtWidgets.QDoubleSpinBox()
-        self.ctlShapeOffset_value.setRange(0, 10)
-        self.ctlShapeOffset_value.setSingleStep(.05)
-        self.ctlShapeOffset_value.setValue(.05)
-        self.sideRange_check = QtWidgets.QCheckBox(
+        self.offset = QtWidgets.QDoubleSpinBox()
+        self.offset.setRange(0, 10)
+        self.offset.setSingleStep(.05)
+        self.offset.setValue(.05)
+        self.sideRange = QtWidgets.QCheckBox(
             "Use Z axis for wide calculation (i.e: Horse and fish side eyes)")
-        self.sideRange_check.setChecked(False)
+        self.sideRange.setChecked(False)
 
         self.ctlGrp_label = QtWidgets.QLabel("Controls Group:")
-        self.ctlGrp_lineEdit = QtWidgets.QLineEdit()
+        self.ctlGrp = QtWidgets.QLineEdit()
         self.ctlGrp_button = QtWidgets.QPushButton("<<")
 
         self.deformersGrp_label = QtWidgets.QLabel("Deformers Group:")
-        self.deformersGrp_lineEdit = QtWidgets.QLineEdit()
+        self.defGrp = QtWidgets.QLineEdit()
         self.deformersGrp_button = QtWidgets.QPushButton("<<")
 
         # Main buttons
@@ -980,14 +983,14 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         eyeball_layout = QtWidgets.QHBoxLayout()
         eyeball_layout.setContentsMargins(1, 1, 1, 1)
         eyeball_layout.addWidget(self.eyeball_label)
-        eyeball_layout.addWidget(self.eyeball_lineEdit)
+        eyeball_layout.addWidget(self.eyeMesh)
         eyeball_layout.addWidget(self.eyeball_button)
 
         # Edge Loop Layout
         edgeloop_layout = QtWidgets.QHBoxLayout()
         edgeloop_layout.setContentsMargins(1, 1, 1, 1)
         edgeloop_layout.addWidget(self.edgeloop_label)
-        edgeloop_layout.addWidget(self.edgeloop_lineEdit)
+        edgeloop_layout.addWidget(self.edgeLoop)
         edgeloop_layout.addWidget(self.edgeloop_button)
 
         # Geometry Input Layout
@@ -1000,7 +1003,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         # Blink Height Layout
         blinkHeight_layout = QtWidgets.QHBoxLayout()
         blinkHeight_layout.setContentsMargins(1, 1, 1, 1)
-        blinkHeight_layout.addWidget(self.blinkHeight_value)
+        blinkHeight_layout.addWidget(self.blinkH)
         blinkHeight_layout.addWidget(self.blinkHeight_slider)
         self.blinkHeight_group.setLayout(blinkHeight_layout)
 
@@ -1008,22 +1011,22 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         tracking_layout = QtWidgets.QVBoxLayout()
         layout = QtWidgets.QHBoxLayout()
         layout.addWidget(QtWidgets.QLabel("Upper Vertical"))
-        layout.addWidget(self.upperVTrack_spinbox)
+        layout.addWidget(self.upperVTrack)
         layout.addWidget(QtWidgets.QLabel("Upper Horizontal"))
-        layout.addWidget(self.upperHTrack_spinbox)
+        layout.addWidget(self.upperHTrack)
         tracking_layout.addLayout(layout)
         layout = QtWidgets.QHBoxLayout()
         layout.addWidget(QtWidgets.QLabel("Lower Vertical"))
-        layout.addWidget(self.lowerVTrack_spinbox)
+        layout.addWidget(self.lowerVTrack)
         layout.addWidget(QtWidgets.QLabel("Lower Horizontal"))
-        layout.addWidget(self.lowerHTrack_spinbox)
+        layout.addWidget(self.lowerHTrack)
         tracking_layout.addLayout(layout)
         self.tracking_group.setLayout(tracking_layout)
 
         # joints Layout
         headJnt_layout = QtWidgets.QHBoxLayout()
         headJnt_layout.addWidget(self.headJnt_label)
-        headJnt_layout.addWidget(self.headJnt_lineEdit)
+        headJnt_layout.addWidget(self.headJnt)
         headJnt_layout.addWidget(self.headJnt_button)
 
         joints_layout = QtWidgets.QVBoxLayout()
@@ -1035,29 +1038,29 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         skinLoops_layout = QtWidgets.QGridLayout()
         skinLoops_layout.addWidget(self.rigidLoops_label, 0, 0)
         skinLoops_layout.addWidget(self.falloffLoops_label, 0, 1)
-        skinLoops_layout.addWidget(self.rigidLoops_value, 1, 0)
-        skinLoops_layout.addWidget(self.falloffLoops_value, 1, 1)
+        skinLoops_layout.addWidget(self.rigidLoops, 1, 0)
+        skinLoops_layout.addWidget(self.falloffLoops, 1, 1)
 
         topoSkin_layout = QtWidgets.QVBoxLayout()
         topoSkin_layout.setContentsMargins(6, 4, 6, 4)
-        topoSkin_layout.addWidget(self.topSkin_check, alignment=0)
+        topoSkin_layout.addWidget(self.doSkin, alignment=0)
         topoSkin_layout.addLayout(skinLoops_layout)
         self.topoSkin_group.setLayout(topoSkin_layout)
 
         # Manual Corners Layout
         intCorner_layout = QtWidgets.QHBoxLayout()
         intCorner_layout.addWidget(self.intCorner_label)
-        intCorner_layout.addWidget(self.intCorner_lineEdit)
+        intCorner_layout.addWidget(self.intCorner)
         intCorner_layout.addWidget(self.intCorner_button)
 
         extCorner_layout = QtWidgets.QHBoxLayout()
         extCorner_layout.addWidget(self.extCorner_label)
-        extCorner_layout.addWidget(self.extCorner_lineEdit)
+        extCorner_layout.addWidget(self.extCorner)
         extCorner_layout.addWidget(self.extCorner_button)
 
         manualCorners_layout = QtWidgets.QVBoxLayout()
         manualCorners_layout.setContentsMargins(6, 4, 6, 4)
-        manualCorners_layout.addWidget(self.manualCorners_check, alignment=0)
+        manualCorners_layout.addWidget(self.customCorner, alignment=0)
         manualCorners_layout.addLayout(intCorner_layout)
         manualCorners_layout.addLayout(extCorner_layout)
         self.manualCorners_group.setLayout(manualCorners_layout)
@@ -1065,18 +1068,18 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         # Options Layout
         parent_layout = QtWidgets.QHBoxLayout()
         parent_layout.addWidget(self.parent_label)
-        parent_layout.addWidget(self.parent_lineEdit)
+        parent_layout.addWidget(self.parent_node)
         parent_layout.addWidget(self.parent_button)
         offset_layout = QtWidgets.QHBoxLayout()
         offset_layout.addWidget(self.ctlShapeOffset_label)
-        offset_layout.addWidget(self.ctlShapeOffset_value)
+        offset_layout.addWidget(self.offset)
         ctlGrp_layout = QtWidgets.QHBoxLayout()
         ctlGrp_layout.addWidget(self.ctlGrp_label)
-        ctlGrp_layout.addWidget(self.ctlGrp_lineEdit)
+        ctlGrp_layout.addWidget(self.ctlGrp)
         ctlGrp_layout.addWidget(self.ctlGrp_button)
         deformersGrp_layout = QtWidgets.QHBoxLayout()
         deformersGrp_layout.addWidget(self.deformersGrp_label)
-        deformersGrp_layout.addWidget(self.deformersGrp_lineEdit)
+        deformersGrp_layout.addWidget(self.defGrp)
         deformersGrp_layout.addWidget(self.deformersGrp_button)
 
         options_layout = QtWidgets.QVBoxLayout()
@@ -1085,7 +1088,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         options_layout.addLayout(offset_layout)
         options_layout.addWidget(self.blinkHeight_group)
         options_layout.addWidget(self.tracking_group)
-        options_layout.addWidget(self.sideRange_check)
+        options_layout.addWidget(self.sideRange)
         options_layout.addLayout(ctlGrp_layout)
         options_layout.addLayout(deformersGrp_layout)
         self.options_group.setLayout(options_layout)
@@ -1093,13 +1096,13 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         # Name prefix
         namePrefix_layout = QtWidgets.QVBoxLayout()
         namePrefix_layout.setContentsMargins(1, 1, 1, 1)
-        namePrefix_layout.addWidget(self.prefix_lineEdit)
+        namePrefix_layout.addWidget(self.namePrefix)
         self.prefix_group.setLayout(namePrefix_layout)
 
         # Name prefix
         controlExtension_layout = QtWidgets.QVBoxLayout()
         controlExtension_layout.setContentsMargins(1, 1, 1, 1)
-        controlExtension_layout.addWidget(self.control_lineEdit)
+        controlExtension_layout.addWidget(self.ctlName)
         self.control_group.setLayout(controlExtension_layout)
 
         # Main Layout
@@ -1119,17 +1122,17 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.setLayout(main_layout)
 
     def create_connections(self):
-        self.blinkHeight_value.valueChanged[int].connect(
+        self.blinkH.valueChanged[int].connect(
             self.blinkHeight_slider.setValue)
         self.blinkHeight_slider.valueChanged[int].connect(
-            self.blinkHeight_value.setValue)
+            self.blinkH.setValue)
 
         self.eyeball_button.clicked.connect(partial(self.populate_object,
-                                                    self.eyeball_lineEdit))
+                                                    self.eyeMesh))
         self.parent_button.clicked.connect(partial(self.populate_object,
-                                                   self.parent_lineEdit))
+                                                   self.parent_node))
         self.headJnt_button.clicked.connect(partial(self.populate_object,
-                                                    self.headJnt_lineEdit,
+                                                    self.headJnt,
                                                     1))
 
         self.edgeloop_button.clicked.connect(self.populate_edgeloop)
@@ -1139,17 +1142,17 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.export_button.clicked.connect(self.exportDict)
 
         self.intCorner_button.clicked.connect(partial(self.populate_element,
-                                                      self.intCorner_lineEdit,
+                                                      self.intCorner,
                                                       "vertex"))
         self.extCorner_button.clicked.connect(partial(self.populate_element,
-                                                      self.extCorner_lineEdit,
+                                                      self.extCorner,
                                                       "vertex"))
 
         self.ctlGrp_button.clicked.connect(partial(self.populate_element,
-                                                   self.ctlGrp_lineEdit,
+                                                   self.ctlGrp,
                                                    "objectSet"))
         self.deformersGrp_button.clicked.connect(partial(
-            self.populate_element, self.deformersGrp_lineEdit, "objectSet"))
+            self.populate_element, self.defGrp, "objectSet"))
 
     # SLOTS ##########################################################
     def populate_element(self, lEdit, oType="transform"):
@@ -1202,7 +1205,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             elif len(edgeList.split(",")) < 4:
                 pm.displayWarning("The minimun edge count is 4")
             else:
-                self.edgeloop_lineEdit.setText(edgeList)
+                self.edgeLoop.setText(edgeList)
 
         else:
             pm.displayWarning("Please select first the eyelid edge loop.")
@@ -1218,7 +1221,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
     def buildRig(self):
         self.populateDict()
-        eyeRig(*self.buildDict)
+        eyeRig(**self.buildDict)
 
     def exportDict(self):
         self.populateDict()
@@ -1260,7 +1263,7 @@ class eyeRigUI(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 # build lips from json file:
 def eyesFromfile(path):
     buildDict = json.load(open(path))
-    eyeRig(*buildDict)
+    eyeRig(**buildDict)
 
 
 def showEyeRigUI(*args):
@@ -1268,10 +1271,10 @@ def showEyeRigUI(*args):
 
 
 if __name__ == "__main__":
-    showEyeRigUI()
+    #showEyeRigUI()
 
-    # path = "C:\\Users\\miquel\\Desktop\\eye_L.eyes"
-    # eyesFromfile(path)
+    path = r"C:\Users\admin\Desktop\temp.eyes"
+    eyesFromfile(path)
 
     # path = "C:\\Users\\miquel\\Desktop\\eye_R.eyes"
     # eyesFromfile(path)

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -4,6 +4,7 @@ import json
 import traceback
 from functools import partial
 
+import mgear
 import mgear.core.pyqt as gqt
 import pymel.core as pm
 from maya.app.general.mayaMixin import MayaQWidgetDockableMixin
@@ -351,11 +352,17 @@ def eyeRig(eyeMesh=None,
         tt = t
     aimTrigger_root = primitive.addTransform(
         center_lookat, setName("aimTrigger_root"), tt)
+    # For some unknown reason the right side gets scewed rotation values
+    mgear.core.transform.resetTransform(aimTrigger_root)
     aimTrigger_lvl = primitive.addTransform(
         aimTrigger_root, setName("aimTrigger_lvl"), tt)
+    # For some unknown reason the right side gets scewed rotation values
+    mgear.core.transform.resetTransform(aimTrigger_lvl)
     aimTrigger_lvl.attr("tz").set(1.0)
     aimTrigger_ref = primitive.addTransform(
         aimTrigger_lvl, setName("aimTrigger_ref"), tt)
+    # For some unknown reason the right side gets scewed rotation values
+    mgear.core.transform.resetTransform(aimTrigger_ref)
     aimTrigger_ref.attr("tz").set(0.0)
     # connect  trigger with arrow_ctl
     pm.parentConstraint(arrow_ctl, aimTrigger_ref, mo=True)

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -661,7 +661,6 @@ def eyeRig(eyeMesh,
                                              "float",
                                              .02,
                                              minValue=0,
-                                             maxValue=1,
                                              keyable=False,
                                              channelBox=True)
     upHTracking_att = attribute.addAttribute(up_ctl,
@@ -669,7 +668,6 @@ def eyeRig(eyeMesh,
                                              "float",
                                              .01,
                                              minValue=0,
-                                             maxValue=1,
                                              keyable=False,
                                              channelBox=True)
 
@@ -678,7 +676,6 @@ def eyeRig(eyeMesh,
                                               "float",
                                               .01,
                                               minValue=0,
-                                              maxValue=1,
                                               keyable=False,
                                               channelBox=True)
     lowHTracking_att = attribute.addAttribute(low_ctl,
@@ -686,7 +683,6 @@ def eyeRig(eyeMesh,
                                               "float",
                                               .01,
                                               minValue=0,
-                                              maxValue=1,
                                               keyable=False,
                                               channelBox=True)
 

--- a/scripts/mgear/rigbits/menu.py
+++ b/scripts/mgear/rigbits/menu.py
@@ -8,7 +8,8 @@ from mgear.rigbits import (rbf_manager_ui,
                            lips_rigger,
                            channelWrangler,
                            proxySlicer,
-                           utils)
+                           utils,
+                           mirror_controls)
 from mgear.core import string
 from functools import partial
 
@@ -25,6 +26,7 @@ def install():
         ("-----", None),
         (None, gimmick_submenu),
         ("-----", None),
+        ("Mirror Controls", mirror_controls.show),
         ("Replace Shape", rigbits.replaceShape),
         ("-----", None),
         ("Match All Transform", rigbits.matchWorldXform),

--- a/scripts/mgear/rigbits/mirror_controls.py
+++ b/scripts/mgear/rigbits/mirror_controls.py
@@ -1,0 +1,144 @@
+import pymel.core as pc
+from maya.app.general.mayaMixin import MayaQWidgetDockableMixin
+
+import mgear
+from mgear.vendor.Qt import QtCore, QtWidgets
+
+
+def mirror_selection():
+    pairs = []
+    for source in pc.selected():
+        target = get_opposite_control(source)
+        if target:
+            pairs.append([source, target])
+
+    mirror_pairs(pairs)
+
+
+def get_controls_without_string(exclusion_string):
+    nodes = []
+    for node in pc.PyNode("rig_controllers_grp").members():
+        if exclusion_string in node.name():
+            continue
+
+        nodes.append(node)
+
+    return nodes
+
+
+def get_opposite_control(node):
+    target_name = mgear.core.string.convertRLName(node.name())
+    target = None
+    if pc.objExists(target_name):
+        target = pc.PyNode(target_name)
+    return target
+
+
+def mirror_left_to_right():
+    pairs = []
+    for source in get_controls_without_string("_R"):
+        target = get_opposite_control(source)
+        if target:
+            pairs.append([source, target])
+
+    mirror_pairs(pairs)
+
+
+def mirror_right_to_left():
+    pairs = []
+    for source in get_controls_without_string("_L"):
+        target = get_opposite_control(source)
+        if target:
+            pairs.append([source, target])
+
+    mirror_pairs(pairs)
+
+
+def mirror_pairs(pairs):
+    # Modify control shapes
+    for source, target in pairs:
+        # Copy shapes
+        source_copy = pc.duplicate(source)[0]
+        mgear.core.attribute.setKeyableAttributes(
+            source_copy,
+            ["tx", "ty", "tz", "ro", "rx", "ry", "rz", "sx", "sy", "sz"]
+        )
+
+        # Delete children except shapes
+        for child in source_copy.getChildren():
+            if child.nodeType() != "nurbsCurve":
+                pc.delete(child)
+
+        # Mirror
+        pc.select(clear=True)
+        grp = pc.group(world=True)
+        pc.parent(source_copy, grp)
+        grp.scaleX.set(-1)
+
+        # Reparent, freeze transforms and match color
+        pc.parent(source_copy, target)
+        pc.makeIdentity(source_copy, apply=True, t=1, r=1, s=1, n=0)
+        pc.parent(source_copy, target.getParent())
+        mgear.core.curve.set_color(
+            source_copy, mgear.core.curve.get_color(target)
+        )
+
+        # Replace shape
+        mgear.rigbits.replaceShape(source_copy, [target])
+
+        # Clean up
+        pc.delete(grp)
+        pc.delete(source_copy)
+
+
+class mirror_controls_ui(MayaQWidgetDockableMixin, QtWidgets.QDialog):
+
+    def __init__(self, parent=None):
+        super(mirror_controls_ui, self).__init__(parent)
+
+        self.setWindowTitle("Mirror Controls")
+        self.setWindowFlags(QtCore.Qt.Window)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose, 1)
+        self.setMinimumSize(QtCore.QSize(350, 0))
+
+        layout = QtWidgets.QVBoxLayout(self)
+        self.selection_button = QtWidgets.QRadioButton("Selection")
+        self.selection_button.setChecked(True)
+        layout.addWidget(self.selection_button)
+
+        self.left_to_right_button = QtWidgets.QRadioButton("Left to Right")
+        layout.addWidget(self.left_to_right_button)
+
+        self.right_to_left_button = QtWidgets.QRadioButton("Right to Left")
+        layout.addWidget(self.right_to_left_button)
+
+        self.mirror_button = QtWidgets.QPushButton("Mirror Controls")
+        layout.addWidget(self.mirror_button)
+
+        self.mirror_button.clicked.connect(self.mirror_button_pressed)
+
+    def mirror_button_pressed(self):
+        pc.system.undoInfo(openChunk=True)
+
+        # Store selection
+        selection = pc.selected()
+
+        if self.selection_button.isChecked():
+            mirror_selection()
+        if self.left_to_right_button.isChecked():
+            mirror_left_to_right()
+        if self.right_to_left_button.isChecked():
+            mirror_right_to_left()
+
+        # Restore selection
+        pc.select(selection)
+
+        pc.system.undoInfo(closeChunk=True)
+
+
+def show(*args):
+    mgear.core.pyqt.showDialog(mirror_controls_ui)
+
+
+if __name__ == "__main__":
+    show()


### PR DESCRIPTION
I messed up the branches so the mirror controls tool PR (https://github.com/mgear-dev/rigbits/pull/25) needs to be merged before this.

Also I'm sorry there are so many changes. I should have divided it up into smaller PRs.

**Remove maximum restrictions from vtrack and htrack**
I felt that 0-1 wasn't always enough, so lifted the maximum restrictions on the vTrack and hTrack attributes.

**Vertical/Horizontal tracking settings**
I exposed the Vertical and Horizontal tracking to the UI and config.

**Import and Export settings directly**
This is a biggy since its not backwards compatible with older ```*.eyes``` files.

Previously the tool was assigning UI settings to a list wrapped in a dictionary. This made it very tricky to work with older ```*.eyes``` files since a certain number of arguments were expected.
By mapping the UI attribute names directly to the build method with a dictionary, we can import ```*.eyes``` files and populate the UI without knowing the quantity of settings. We also don't have to remember to update the export method, since it'll just look at its own ```__dict__``` for attribute names.

**Aim Controller option**
You can assign an aim controller, so you don't duplicated controller when used with shifters eye component.

**Add joints group option**
You can assign a joints group/parent, so the rig ends up playing nicer with mGear visibility controls.

Fix for https://github.com/mgear-dev/rigbits/issues/24

**Fix screwed lookat transforms on right side**
There was some odd offset transforms that caused the vTrack and hTrack on the right side to behave odd.

Let me know if there is something I haven't explained well enough.