### PR TITLE
Fix facial rigger import/export filedialog.

### DIFF
--- a/scripts/mgear/rigbits/facial_rigger/eye_rigger.py
+++ b/scripts/mgear/rigbits/facial_rigger/eye_rigger.py
@@ -1231,7 +1231,7 @@ class ui(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             lib.get_settings_from_widget(self), indent=4, sort_keys=True
         )
 
-        file_path = lib.get_file_path(self.filter)
+        file_path = lib.get_file_path(self.filter, "save")
         if not file_path:
             return
 
@@ -1239,7 +1239,7 @@ class ui(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             f.write(data_string)
 
     def import_settings(self):
-        file_path = lib.get_file_path(self.filter)
+        file_path = lib.get_file_path(self.filter, "open")
         if not file_path:
             return
 

--- a/scripts/mgear/rigbits/facial_rigger/lib.py
+++ b/scripts/mgear/rigbits/facial_rigger/lib.py
@@ -57,10 +57,16 @@ def get_settings_from_widget(widget):
     return settings
 
 
-def get_file_path(filter):
+def get_file_path(filter, mode):
+    filemode = None
+    if mode == "open":
+        filemode = 1
+    if mode == "save":
+        filemode = 2
+
     file_path = pymel.core.fileDialog2(
         dialogStyle=2,
-        fileMode=1,
+        fileMode=filemode,
         fileFilter=filter
     )
     if not file_path:

--- a/scripts/mgear/rigbits/facial_rigger/lib.py
+++ b/scripts/mgear/rigbits/facial_rigger/lib.py
@@ -62,7 +62,7 @@ def get_file_path(filter, mode):
     if mode == "open":
         filemode = 1
     if mode == "save":
-        filemode = 2
+        filemode = 0
 
     file_path = pymel.core.fileDialog2(
         dialogStyle=2,

--- a/scripts/mgear/rigbits/facial_rigger/lips_rigger.py
+++ b/scripts/mgear/rigbits/facial_rigger/lips_rigger.py
@@ -1040,7 +1040,7 @@ class ui(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             lib.get_settings_from_widget(self), indent=4, sort_keys=True
         )
 
-        file_path = lib.get_file_path(self.filter)
+        file_path = lib.get_file_path(self.filter, "save")
         if not file_path:
             return
 
@@ -1048,7 +1048,7 @@ class ui(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             f.write(data_string)
 
     def import_settings(self):
-        file_path = lib.get_file_path(self.filter)
+        file_path = lib.get_file_path(self.filter, "open")
         if not file_path:
             return
 


### PR DESCRIPTION
**Problem**

The export filedialog was set to "Open" instead of "Save".

**Solution**

Add mode to ```lib.get_file_path```.