### PR TITLE
FIX -  Parameter on function "def set_driven_key" unused

### DIFF
--- a/scripts/mgear/rigbits/sdk_manager/core.py
+++ b/scripts/mgear/rigbits/sdk_manager/core.py
@@ -319,8 +319,8 @@ def set_driven_key(driverAttr,
 
     # Setting Attrs
     if animUU:
-        animUU.preInfinity.set(0)
-        animUU.postInfinity.set(0)
+        animUU.preInfinity.set(preInfinity)
+        animUU.postInfinity.set(postInfinity)
 
     # renaming
     if animUU:


### PR DESCRIPTION
Problem:
There were some parameters important for the set driven keys unused inside of the function which was resulting and different behaviour than the expected.

Solution:
Fill the attributes inside of this function with the incoming parameters.
```

                   preInfinity=0,
                   postInfinity=0,

```