### PR TITLE
Mirror controls required target shape to exist

### DIFF
--- a/scripts/mgear/rigbits/__init__.py
+++ b/scripts/mgear/rigbits/__init__.py
@@ -395,6 +395,7 @@ def replaceShape(source=None, targets=None, *args):
     for target in targets:
         source2 = pm.duplicate(source)[0]
         shape = target.getShapes()
+        cnx = []
         if shape:
             cnx = shape[0].listConnections(plugs=True, c=True)
             cnx = [[c[1], c[0].shortName()] for c in cnx]

--- a/scripts/mgear/rigbits/eye_rigger.py
+++ b/scripts/mgear/rigbits/eye_rigger.py
@@ -401,10 +401,12 @@ def eyeRig(eyeMesh,
     # adding parent average contrains to odd controls
     for i, ctl in enumerate(upControls):
         if utils.is_odd(i):
-            pm.parentConstraint(upControls[i - 1],
+            cns_node = pm.parentConstraint(upControls[i - 1],
                                 upControls[i + 1],
                                 ctl.getParent(),
                                 mo=True)
+            # Make the constraint "noFlip"
+            cns_node.interpType.set(0)
 
     # lower eyelid controls
     lowControls = [upControls[0]]
@@ -480,10 +482,12 @@ def eyeRig(eyeMesh,
     # adding parent average contrains to odd controls
     for i, ctl in enumerate(lowControls):
         if utils.is_odd(i):
-            pm.parentConstraint(lowControls[i - 1],
+            cns_node = pm.parentConstraint(lowControls[i - 1],
                                 lowControls[i + 1],
                                 ctl.getParent(),
                                 mo=True)
+            # Make the constraint "noFlip"
+            cns_node.interpType.set(0)
 
     # Connecting control crvs with controls
     applyop.gear_curvecns_op(upCrv_ctl, upControls)

--- a/scripts/mgear/rigbits/facial_rigger/eye_rigger.py
+++ b/scripts/mgear/rigbits/facial_rigger/eye_rigger.py
@@ -438,13 +438,15 @@ def rig(eyeMesh=None,
             npoBase.attr("ry").set(180)
             npoBase.attr("sz").set(-1)
 
-    # adding parent average contrains to odd controls
+    # adding parent constraints to odd controls
     for i, ctl in enumerate(upControls):
         if utils.is_odd(i):
-            pm.parentConstraint(upControls[i - 1],
+            cns_node = pm.parentConstraint(upControls[i - 1],
                                 upControls[i + 1],
                                 ctl.getParent(),
                                 mo=True)
+            # Make the constraint "noFlip"
+            cns_node.interpType.set(0)
 
     # lower eyelid controls
     lowControls = [upControls[0]]
@@ -518,13 +520,15 @@ def rig(eyeMesh=None,
         node.add_controller_tag(lctl, over_ctl)
     lowControls.append(upControls[-1])
 
-    # adding parent average contrains to odd controls
+    # adding parent constraints to odd controls
     for i, ctl in enumerate(lowControls):
         if utils.is_odd(i):
-            pm.parentConstraint(lowControls[i - 1],
+            cns_node = pm.parentConstraint(lowControls[i - 1],
                                 lowControls[i + 1],
                                 ctl.getParent(),
                                 mo=True)
+            # Make the constraint "noFlip"
+            cns_node.interpType.set(0)
 
     # Connecting control crvs with controls
     applyop.gear_curvecns_op(upCrv_ctl, upControls)

--- a/scripts/mgear/rigbits/facial_rigger/lips_rigger.py
+++ b/scripts/mgear/rigbits/facial_rigger/lips_rigger.py
@@ -590,6 +590,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.75)
     cns_node.attr(upControls[3].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[0],
                                    upControls[3],
@@ -598,6 +599,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.25)
     cns_node.attr(upControls[3].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[3],
                                    upControls[6],
@@ -606,6 +608,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[3].name() + "W0").set(.75)
     cns_node.attr(upControls[6].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[3],
                                    upControls[6],
@@ -614,6 +617,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[3].name() + "W0").set(.25)
     cns_node.attr(upControls[6].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     # low
     cns_node = pm.parentConstraint(upControls[0],
@@ -623,6 +627,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.75)
     cns_node.attr(lowControls[2].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[0],
                                    lowControls[2],
@@ -631,6 +636,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.25)
     cns_node.attr(lowControls[2].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(lowControls[2],
                                    upControls[6],
@@ -639,6 +645,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(lowControls[2].name() + "W0").set(.75)
     cns_node.attr(upControls[6].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(lowControls[2],
                                    upControls[6],
@@ -647,6 +654,7 @@ def rig(edge_loop="",
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(lowControls[2].name() + "W0").set(.25)
     cns_node.attr(upControls[6].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     ###########################################
     # Connecting rig
@@ -676,6 +684,7 @@ def rig(edge_loop="",
             return
 
         # in order to avoid flips lets create a reference transform
+        # also to avoid flips, set any multi target parentConstraint to noFlip
         ref_cns_list = []
         for cns_ref in [head_joint, jaw_joint]:
 
@@ -688,21 +697,23 @@ def rig(edge_loop="",
             ref.setMatrix(t, worldSpace=True)
             ref_cns_list.append(ref)
         # right corner connection
-        pm.parentConstraint(ref_cns_list[0],
+        cns_node = pm.parentConstraint(ref_cns_list[0],
                             ref_cns_list[1],
                             upControls[0].getParent(),
                             mo=True)
+        cns_node.interpType.set(0) # noFlip
         # left corner connection
-        pm.parentConstraint(ref_cns_list[0],
+        cns_node = pm.parentConstraint(ref_cns_list[0],
                             ref_cns_list[1],
                             upControls[-1].getParent(),
                             mo=True)
+        cns_node.interpType.set(0) # noFlip
         # up control connection
-        pm.parentConstraint(head_joint,
+        cns_node = pm.parentConstraint(head_joint,
                             upControls[3].getParent(),
                             mo=True)
         # low control connection
-        pm.parentConstraint(jaw_joint,
+        cns_node = pm.parentConstraint(jaw_joint,
                             lowControls[2].getParent(),
                             mo=True)
 

--- a/scripts/mgear/rigbits/lips_rigger.py
+++ b/scripts/mgear/rigbits/lips_rigger.py
@@ -419,6 +419,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.75)
     cns_node.attr(upControls[3].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[0],
                                    upControls[3],
@@ -427,6 +428,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.25)
     cns_node.attr(upControls[3].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[3],
                                    upControls[6],
@@ -435,6 +437,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[3].name() + "W0").set(.75)
     cns_node.attr(upControls[6].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[3],
                                    upControls[6],
@@ -443,6 +446,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[3].name() + "W0").set(.25)
     cns_node.attr(upControls[6].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     # low
     cns_node = pm.parentConstraint(upControls[0],
@@ -452,6 +456,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.75)
     cns_node.attr(lowControls[2].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(upControls[0],
                                    lowControls[2],
@@ -460,6 +465,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(upControls[0].name() + "W0").set(.25)
     cns_node.attr(lowControls[2].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(lowControls[2],
                                    upControls[6],
@@ -468,6 +474,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(lowControls[2].name() + "W0").set(.75)
     cns_node.attr(upControls[6].name() + "W1").set(.25)
+    cns_node.interpType.set(0) # noFlip
 
     cns_node = pm.parentConstraint(lowControls[2],
                                    upControls[6],
@@ -476,6 +483,7 @@ def lipsRig(eLoop,
                                    skipRotate=["x", "y", "z"])
     cns_node.attr(lowControls[2].name() + "W0").set(.25)
     cns_node.attr(upControls[6].name() + "W1").set(.75)
+    cns_node.interpType.set(0) # noFlip
 
     ##################
     # Joints
@@ -621,6 +629,7 @@ def lipsRig(eLoop,
             return
 
         # in order to avoid flips lets create a reference transform
+        # also to avoid flips, set any multi target parentConstraint to noFlip
         ref_cns_list = []
         for cns_ref in [headJnt, jawJnt]:
 
@@ -633,21 +642,23 @@ def lipsRig(eLoop,
             ref.setMatrix(t, worldSpace=True)
             ref_cns_list.append(ref)
         # right corner connection
-        pm.parentConstraint(ref_cns_list[0],
+        cns_node = pm.parentConstraint(ref_cns_list[0],
                             ref_cns_list[1],
                             upControls[0].getParent(),
                             mo=True)
+        cns_node.interpType.set(0) # noFlip
         # left corner connection
-        pm.parentConstraint(ref_cns_list[0],
+        cns_node = pm.parentConstraint(ref_cns_list[0],
                             ref_cns_list[1],
                             upControls[-1].getParent(),
                             mo=True)
+        cns_node.interpType.set(0) # noFlip
         # up control connection
-        pm.parentConstraint(headJnt,
+        cns_node = pm.parentConstraint(headJnt,
                             upControls[3].getParent(),
                             mo=True)
         # low control connection
-        pm.parentConstraint(jawJnt,
+        cns_node = pm.parentConstraint(jawJnt,
                             lowControls[2].getParent(),
                             mo=True)
 

--- a/scripts/mgear/rigbits/mirror_controls.py
+++ b/scripts/mgear/rigbits/mirror_controls.py
@@ -97,9 +97,7 @@ def mirror_pairs(pairs):
         pc.parent(source_copy, target.getParent())
         targetColor = mgear.core.curve.get_color(target)
         if targetColor:
-            mgear.core.curve.set_color(
-                source_copy, targetColor)
-            )
+            mgear.core.curve.set_color(source_copy, targetColor)
 
         # Replace shape
         mgear.rigbits.replaceShape(source_copy, [target])

--- a/scripts/mgear/rigbits/mirror_controls.py
+++ b/scripts/mgear/rigbits/mirror_controls.py
@@ -95,9 +95,11 @@ def mirror_pairs(pairs):
         pc.parent(source_copy, target)
         pc.makeIdentity(source_copy, apply=True, t=1, r=1, s=1, n=0)
         pc.parent(source_copy, target.getParent())
-        mgear.core.curve.set_color(
-            source_copy, mgear.core.curve.get_color(target)
-        )
+        targetColor = mgear.core.curve.get_color(target)
+        if targetColor:
+            mgear.core.curve.set_color(
+                source_copy, targetColor)
+            )
 
         # Replace shape
         mgear.rigbits.replaceShape(source_copy, [target])


### PR DESCRIPTION
There was a bug where rigbits.mirror_control required a target shape to exist. If the shape did not exist already, two errors occurred.
1. cnx was an undeclared variable
2. Getting the color of the target shape returned None and then tried to set color to None.