### PR TITLE
Update menu.py

### DIFF
--- a/scripts/mgear/rigbits/menu.py
+++ b/scripts/mgear/rigbits/menu.py
@@ -122,7 +122,7 @@ def _ctl_submenu(parent_menu_id, name, cCtl=False):
     commands = []
     for c in ctls:
         cm = string.removeInvalidCharacter(c).lower()
-        commands.append([c, "rigbits.createCTL('{0}', {1})".format(cm,
+        commands.append([c, "from mgear import rigbits\nrigbits.createCTL('{0}', {1})".format(cm,
                                                                    str(cCtl))])
     mgear.menu.install(name, commands, parent_menu_id)
 


### PR DESCRIPTION
In the _ctl_submenu function of adding parentCTL/childCTL, the rigbits module of mgear is not imported, which leads to an error message. The corresponding control cannot be created. It can only be created correctly after clicking other menus. For this reason, I added "from mgear import rigbits". Code and make it execute correctly.
The error description is in the forum http://forum.mgear-framework.com/t/mgear-3-7-8-rigbits-added-parent-child-ctl-error/2051